### PR TITLE
Add blurBackground option

### DIFF
--- a/background.js
+++ b/background.js
@@ -146,10 +146,10 @@ function handleNewPage(newTab, selectedTab, sendResponse) {
        
         sendResponse({
           dimmerAction: tabIsActive ? "create" : "create_suspended",
-	  options: {
-	    blurBackground: getLocal('blurBackground'),
-	    delay: getLocal('dimmerDelay'),
-	  }
+	    options: {
+	      blurBackground: getLocal('blurBackground'),
+	      delay: getLocal('dimmerDelay'),
+	    }
         });
 
         responseSent = true;

--- a/background.js
+++ b/background.js
@@ -146,8 +146,10 @@ function handleNewPage(newTab, selectedTab, sendResponse) {
        
         sendResponse({
           dimmerAction: tabIsActive ? "create" : "create_suspended",
-          delay: getLocal('dimmerDelay'),
-          appearance: { transparent: false }
+		  options: {
+			  blurBackground: getLocal('blurBackground'),
+			  delay: getLocal('dimmerDelay'),
+		  }
         });
 
         responseSent = true;

--- a/background.js
+++ b/background.js
@@ -146,10 +146,10 @@ function handleNewPage(newTab, selectedTab, sendResponse) {
        
         sendResponse({
           dimmerAction: tabIsActive ? "create" : "create_suspended",
-		  options: {
-			  blurBackground: getLocal('blurBackground'),
-			  delay: getLocal('dimmerDelay'),
-		  }
+	  options: {
+	    blurBackground: getLocal('blurBackground'),
+	    delay: getLocal('dimmerDelay'),
+	  }
         });
 
         responseSent = true;

--- a/dimmer.js
+++ b/dimmer.js
@@ -88,8 +88,8 @@ function addDimmer(delay) {
   dimmer.style.zIndex = "2147483647";
   dimmer.style.background = "#001000";
   if (dimmer_options.blurBackground) {
-	  dimmer.style.background = "rgba(0, 16, 0, .6)";
-	  dimmer.style.backdropFilter = "blur(10px)";
+    dimmer.style.background = "rgba(0, 16, 0, .6)";
+    dimmer.style.backdropFilter = "blur(10px)";
   }
 
   document.body.insertBefore(dimmer, document.body.firstChild);

--- a/dimmer.js
+++ b/dimmer.js
@@ -114,16 +114,16 @@ function watchUrlChanges() {
 
 // Actions
 
-function create(dimmer_el, delay, options) {
+function create(dimmer_el, delay) {
   if (!dimmer_el) {
-    var dimmer = addDimmer(delay, options);
+    var dimmer = addDimmer(delay);
     setDimTimer(dimmer, delay);
   }
 }
 
-function create_suspended(dimmer_el, delay, options) {
+function create_suspended(dimmer_el, delay) {
   if (!dimmer_el) {
-    var dimmer = addDimmer(delay, options);
+    var dimmer = addDimmer(delay);
   }
 }
 

--- a/dimmer.js
+++ b/dimmer.js
@@ -6,8 +6,7 @@ var DIMMER_SWITCH_TEXT = "The timer restarts if you switch away from this tab.";
 var TRACING = false;
 
 var original_url = null;
-var dimmer_delay = null;
-var dimmer_appearance = null;
+var dimmer_options = {};
 
 function clearDimTimer(dimmer) {
   // Clear old timer.
@@ -48,7 +47,7 @@ function setDimTimer(dimmer, delay) {
   timerIdInput.value = timerId;
 }
 
-function addDimmer(delay, appearance) {
+function addDimmer(delay) {
   var dimmer = document.createElement('div');
   dimmer.id = DIMMER_DIV_ID;
 
@@ -86,11 +85,12 @@ function addDimmer(delay, appearance) {
   dimmer.style.height = "100%";
 
   // Background.
-  dimmer.style.background = "#001000";
-  if (appearance && appearance.transparent) {
-    dimmer.style.opacity = "0.95";
-  }
   dimmer.style.zIndex = "2147483647";
+  dimmer.style.background = "#001000";
+  if (dimmer_options.blurBackground) {
+	  dimmer.style.background = "rgba(0, 16, 0, .6)";
+	  dimmer.style.backdropFilter = "blur(10px)";
+  }
 
   document.body.insertBefore(dimmer, document.body.firstChild);
 
@@ -114,16 +114,16 @@ function watchUrlChanges() {
 
 // Actions
 
-function create(dimmer_el, delay, appearance) {
+function create(dimmer_el, delay, options) {
   if (!dimmer_el) {
-    var dimmer = addDimmer(delay, appearance);
+    var dimmer = addDimmer(delay, options);
     setDimTimer(dimmer, delay);
   }
 }
 
-function create_suspended(dimmer_el, delay, appearance) {
+function create_suspended(dimmer_el, delay, options) {
   if (!dimmer_el) {
-    var dimmer = addDimmer(delay, appearance);
+    var dimmer = addDimmer(delay, options);
   }
 }
 
@@ -179,7 +179,7 @@ function dim(action) {
   var action_fn = action_fns[action];
 
   var dimmer_el = document.getElementById(DIMMER_DIV_ID);
-  action_fn(dimmer_el, dimmer_delay, dimmer_appearance);
+  action_fn(dimmer_el, dimmer_options.delay);
 }
 
 /* Forwarder function for calls using executeScript() */
@@ -193,8 +193,7 @@ chrome.extension.sendRequest({}, function(response) {
     window.location.href = response.redirectUrl;
   } else if (response.dimmerAction) {
     // Save dimmer parameters.
-    dimmer_delay = response.delay;
-    dimmer_appearance = response.appearance;
+    dimmer_options = response.options;
     function delayedDimmerFn() {
       if (document.body != null) {
         // The body of the document has started loading, the dimmer can be shown.

--- a/options.html
+++ b/options.html
@@ -59,6 +59,11 @@
     </div>
     <div style="padding-top: 0.3em">
       <label>
+        <label><input id="blurBackground" name="blurBackground" type="checkbox" value="1" />Visually blur website while delaying instead of solid black background</label>
+      </label>
+    </div>
+    <div style="padding-top: 0.3em">
+      <label>
         <label><input id="checkActiveTab" name="checkActiveTab" type="checkbox" value="1" />Block new background tabs opened from a junk page</label>
       </label>
     </div>

--- a/options.js
+++ b/options.js
@@ -133,6 +133,8 @@ function showSettings() {
 
   document.getElementById("checkActiveTab").checked = getLocal('checkActiveTab');
 
+  document.getElementById("blurBackground").checked = getLocal('blurBackground');
+
   // Junk domains.
   clearDomainsFromPage('siteBlacklist');
   if (getLocal('junkDomains').length > 0) {
@@ -185,6 +187,7 @@ function saveSettings() {
   var reset_daily_flag = !!document.getElementById('reset_daily_flag').checked;
 
   var checkActiveTab = document.getElementById("checkActiveTab").checked;
+  var blurBackground = document.getElementById("blurBackground").checked;
 
   // TODO: better validation
   var startTime = parseTime(document.getElementById("startTime").value);
@@ -202,6 +205,7 @@ function saveSettings() {
   setLocal('dimmerDelayIncrement', dimmerDelayIncrement);
   setLocal('reset_daily_flag', reset_daily_flag);
   setLocal('base_delay', base_delay);
+  setLocal('blurBackground', blurBackground);
 
   setLocal('checkActiveTab', checkActiveTab);
   setLocal('junkDomains', junkDomains);


### PR DESCRIPTION
<img width="726" alt="Screen Shot 2020-02-13 at 10 44 23 AM" src="https://user-images.githubusercontent.com/709042/74467570-28f85380-4e4e-11ea-884b-bf3760068fab.png">

<img width="425" alt="Screen Shot 2020-02-13 at 10 47 15 AM" src="https://user-images.githubusercontent.com/709042/74467613-42999b00-4e4e-11ea-927a-a05c2ebcca5b.png">

Adds an option to blur the background instead of using a solid black background. Also cleans up the option passing to `dimmer.js` by consolidating things into an "options" object.
