### PR TITLE
Suppress audio and video playback while page is dimmed

### DIFF
--- a/dimmer.js
+++ b/dimmer.js
@@ -33,6 +33,10 @@ function setDimTimer(dimmer, delay) {
     dimmer.style.display = "none";
 
     showScrollbars();
+
+    if (mediaTimer !== null) {
+      window.clearInterval(mediaTimer);
+    }
   };
 
   // Set timer.
@@ -101,7 +105,38 @@ function addDimmer(delay, appearance) {
   setInterval(watchUrlChanges, 1000);
   // TODO(gintas): Disable watcher when the tab is not active.
 
+  // Pause audio/video
+  suppressMedia();
+
   return dimmer;
+}
+
+var mediaTimer = null;
+
+function suppressMedia() {
+  function pauseAll() {
+    for (var video of document.getElementsByTagName("video")) {
+      if (video.autoplay || !video.paused) {
+        video.autoplay = false;
+        video.pause();
+      }
+    }
+
+    for (var audio of document.getElementsByTagName("audio")) {
+      if (audio.autoplay || !audio.paused) {
+        audio.autoplay = false;
+        audio.pause();
+      }
+    }
+  }
+  pauseAll();
+
+  if (mediaTimer !== null) {
+    window.clearInterval(mediaTimer);
+  }
+
+  // Media elements may be inserted in to the page later...
+  mediaTimer = window.setInterval(pauseAll, 250);
 }
 
 /* Watches for URL changes and reshows the dimmer if a change is detected. */
@@ -136,6 +171,7 @@ function suspend(dimmer_el, delay) {
 function resume(dimmer_el, delay) {
   if (dimmer_el && dimmer_el.style.display != "none") {
     setDimTimer(dimmer_el, delay);
+    suppressMedia();
 
     var switch_text = document.getElementById(DIMMER_DIV_ID + 'stayput');
     switch_text.style.display = "block";
@@ -145,10 +181,10 @@ function resume(dimmer_el, delay) {
 function reshow(dimmer_el, delay) {
   if (dimmer_el) {
     dimmer_el.style.display = "block";
-    
-    hideScrollbars();
 
+    hideScrollbars();
     setDimTimer(dimmer_el, delay);
+    suppressMedia();
     // TODO(gintas): Do not assume that this tab is currently active.
   }
 }

--- a/dimmer.js
+++ b/dimmer.js
@@ -8,6 +8,7 @@ var TRACING = false;
 var original_url = null;
 var dimmer_delay = null;
 var dimmer_appearance = null;
+var media_timer = null;
 
 function clearDimTimer(dimmer) {
   // Clear old timer.
@@ -33,10 +34,7 @@ function setDimTimer(dimmer, delay) {
     dimmer.style.display = "none";
 
     showScrollbars();
-
-    if (mediaTimer !== null) {
-      window.clearInterval(mediaTimer);
-    }
+    unSuppressMedia();
   };
 
   // Set timer.
@@ -111,8 +109,6 @@ function addDimmer(delay, appearance) {
   return dimmer;
 }
 
-var mediaTimer = null;
-
 function suppressMedia() {
   function pauseAll() {
     for (var video of document.getElementsByTagName("video")) {
@@ -131,12 +127,19 @@ function suppressMedia() {
   }
   pauseAll();
 
-  if (mediaTimer !== null) {
-    window.clearInterval(mediaTimer);
+  if (media_timer !== null) {
+    window.clearInterval(media_timer);
   }
 
   // Media elements may be inserted in to the page later...
-  mediaTimer = window.setInterval(pauseAll, 250);
+  media_timer = window.setInterval(pauseAll, 250);
+}
+
+function unSuppressMedia() {
+  if (media_timer !== null) {
+    window.clearInterval(media_timer);
+    media_timer = null;
+  }
 }
 
 /* Watches for URL changes and reshows the dimmer if a change is detected. */
@@ -158,7 +161,7 @@ function create(dimmer_el, delay, appearance) {
 
 function create_suspended(dimmer_el, delay, appearance) {
   if (!dimmer_el) {
-    var dimmer = addDimmer(delay, appearance);
+    addDimmer(delay, appearance);
   }
 }
 


### PR DESCRIPTION
I noticed that when using Crackbook Revival on youtube, videos would play even though the dimmer was shown.

This PR updates the dimmer script so that audio/video elements are paused initially, and then need to be manually un-paused by the user after the dimmer is removed from screen.