### PR TITLE
Add options for text and background color for the dimmer popup.

### DIFF
--- a/background.js
+++ b/background.js
@@ -147,8 +147,10 @@ function handleNewPage(newTab, selectedTab, sendResponse) {
         sendResponse({
           dimmerAction: tabIsActive ? "create" : "create_suspended",
 	    options: {
+	      backgroundColor: getLocal('dimmerBackgroundColor'),
 	      blurBackground: getLocal('blurBackground'),
 	      delay: getLocal('dimmerDelay'),
+	      textColor: getLocal('dimmerTextColor'),
 	    }
         });
 

--- a/dimmer.js
+++ b/dimmer.js
@@ -56,7 +56,7 @@ function addDimmer(delay) {
   // TODO: add a picture
 
   // Message
-  dimmer.style.color = "#ffffff";
+  dimmer.style.color = dimmer_options.textColor;
   dimmer.style.paddingTop = window.innerHeight / 2 - 30 + "px";
   dimmer.style.fontSize = '36px';
   dimmer.style.fontFamily = 'Georgia';
@@ -88,7 +88,7 @@ function addDimmer(delay) {
 
   // Background.
   dimmer.style.zIndex = "2147483647";
-  dimmer.style.background = "#001000";
+  dimmer.style.background = dimmer_options.backgroundColor;
   if (dimmer_options.blurBackground) {
     dimmer.style.background = "rgba(0, 16, 0, .6)";
     dimmer.style.backdropFilter = "blur(10px)";

--- a/lib.js
+++ b/lib.js
@@ -44,6 +44,8 @@ var_defaults = {
   dimmerThreshold: '0',
   dimmerDelay: '3.0',
   dimmerDelayIncrement: '0.05',
+  dimmerBackgroundColor: '"#001000"',
+  dimmerTextColor: '"#ffffff"',
   redirectProbability: '2',
   startTime: '0',
   endTime: '' + 24*60-1,

--- a/options.css
+++ b/options.css
@@ -57,6 +57,11 @@ input#dimmerDelay, input#base_delay, input#dimmerDelayIncrement {
   width: 4em;
 }
 
+input#dimmerBackgroundColor, input#dimmerTextColor {
+  width: 5em;
+  font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+}
+
 input#startTime, input#endTime {
   width: 3.5em;
   padding-left: 0.2em;

--- a/options.html
+++ b/options.html
@@ -54,12 +54,18 @@
       <label>Increase the delay by <input id="dimmerDelayIncrement" class="rightAlign" name="dimmerDelayIncrement" type="text" /> seconds after every block</label>
     </div>
     <div>
+      <label>Use <input id="dimmerBackgroundColor" class="rightAlign" type="text" /> for the background color of the delay message.</label>
+    </div>
+    <div>
+      <label>Use <input id="dimmerTextColor" class="rightAlign" type="text" /> for the text color of the delay message.</label>
+    </div>
+    <div>
       <label><input type="checkbox" id="reset_daily_flag" />Reset the delay every day to </label>
       <input id="base_delay" class="rightAlign" name="base_delay"></input> seconds.
     </div>
     <div style="padding-top: 0.3em">
       <label>
-        <label><input id="blurBackground" name="blurBackground" type="checkbox" value="1" />Visually blur website while delaying instead of solid black background</label>
+        <label><input id="blurBackground" name="blurBackground" type="checkbox" value="1" />Visually blur website while delaying instead of solid background</label>
       </label>
     </div>
     <div style="padding-top: 0.3em">

--- a/options.js
+++ b/options.js
@@ -128,6 +128,8 @@ function showSettings() {
   document.getElementById("dimmerThreshold").value = getLocal('dimmerThreshold');
   document.getElementById("dimmerDelay").value = getLocal('dimmerDelay').toFixed(2);
   document.getElementById("dimmerDelayIncrement").value = getLocal('dimmerDelayIncrement').toFixed(2);
+  document.getElementById("dimmerBackgroundColor").value = getLocal('dimmerBackgroundColor');
+  document.getElementById("dimmerTextColor").value = getLocal('dimmerTextColor');
   document.getElementById("reset_daily_flag").checked = getLocal('reset_daily_flag');
   document.getElementById("base_delay").value = getLocal('base_delay').toFixed(2);
 
@@ -155,6 +157,11 @@ function showSettings() {
   }
 }
 
+function isHtmlColor(strColor){
+  var s = new Option().style;
+  s.color = strColor;
+  return s.color != "";
+}
 
 function saveSettings() {
   /* Save settings from submitted form. */
@@ -177,6 +184,16 @@ function saveSettings() {
   var dimmerDelayIncrement = parseFloat(document.getElementById("dimmerDelayIncrement").value);
   if (isNaN(dimmerDelayIncrement) || dimmerDelayIncrement < 0) {
     dimmerDelayIncrement = getLocal('dimmerDelayIncrement');
+  }
+
+  var dimmerBackgroundColor = document.getElementById('dimmerBackgroundColor').value;
+  if (!isHtmlColor(dimmerBackgroundColor)) {
+    dimmerBackgroundColor = getLocal('dimmerBackgroundColor');
+  }
+
+  var dimmerTextColor = document.getElementById('dimmerTextColor').value;
+  if (!isHtmlColor(dimmerTextColor)) {
+    dimmerTextColor = getLocal('dimmerTextColor');
   }
 
   var base_delay = parseFloat(document.getElementById("base_delay").value);
@@ -203,6 +220,8 @@ function saveSettings() {
   setLocal('dimmerThreshold', dimmerThreshold);
   setLocal('dimmerDelay', dimmerDelay);
   setLocal('dimmerDelayIncrement', dimmerDelayIncrement);
+  setLocal('dimmerBackgroundColor', dimmerBackgroundColor);
+  setLocal('dimmerTextColor', dimmerTextColor);
   setLocal('reset_daily_flag', reset_daily_flag);
   setLocal('base_delay', base_delay);
   setLocal('blurBackground', blurBackground);


### PR DESCRIPTION
I use Dark Reader which inverts the color of the dimmer popup.
So I added color parameters for the text and background of the popup.

This is a little raw and it might be better to have theme option instead, but doing that seemed presumptuous.

I will rework this once #3 is merged, provided you are interested.

![color_config](https://user-images.githubusercontent.com/11370198/74585927-5fe67a80-4fb0-11ea-8f8b-3b2ea8aa5711.png)
