### PR TITLE
add firefox support

### DIFF
--- a/dimmer.js
+++ b/dimmer.js
@@ -227,7 +227,7 @@ function invoke_dimmer(action) {
 }
 
 // On initial load, check with the extension whether action needs to be taken.
-chrome.extension.sendRequest({}, function(response) {
+chrome.runtime.sendMessage({}, function(response) {
   if (response.redirectUrl) {
     window.location.href = response.redirectUrl;
   } else if (response.dimmerAction) {

--- a/options.js
+++ b/options.js
@@ -7,7 +7,8 @@ function getTopDomains(historyItems) {
   var domains = [];
   for (var i = 0; i < historyItems.length; i++) {
     var h = historyItems[i];
-    if (h.url && h.typedCount) {
+    // firefox does not seem to use typedCount, so we use visitCount as a backup
+    if (h.url && (h.typedCount || h.visitCount)) {
       var url = trimWWW(trimProtocol(h.url.trim()));
       var domain = trimPath(url);
 
@@ -20,9 +21,9 @@ function getTopDomains(historyItems) {
 
       if (domains.indexOf(domain) == -1) {
         domains.push(domain);
-        typedCounts[domain] = h.typedCount;
+        typedCounts[domain] = h.typedCount || h.visitCount;
       } else {
-        typedCounts[domain] += h.typedCount;
+        typedCounts[domain] += h.typedCount || h.visitCount;
       }
     }
   }

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 // Mark the domain of the selected tab as junk.
 function markAsJunk() {
-  chrome.tabs.getSelected(null, function (tab) {
+  chrome.tabs.query({ active: true, currentWindow:true }, function (tabs) {
+    var tab = tabs[0];
     var junkDomains = getLocal('junkDomains');
     var domain = trimPath(trimWWW(trimProtocol(tab.url.trim())));
     junkDomains.push(domain);
@@ -12,7 +13,8 @@ function markAsJunk() {
 }
 
 window.onload = function() {
-  chrome.tabs.getSelected(null, function (tab) {
+  chrome.tabs.query({ active: true, currentWindow:true }, function (tabs) {
+    var tab = tabs[0];
     if (!lookupJunkDomain(tab.url) && tab.url.indexOf('.') != -1) {
       // Show current domain.
       var normalized_url = trimWWW(trimProtocol(tab.url.trim()));


### PR DESCRIPTION
Firefox was pretty close to already working, had to change a couple api calls to non-depreciated versions and check different properties for the generate from history function.

Near as I can tell everything works, from a maintenance perspective I think it wouldn't be very hard to maintain this as firefox's api is almost identical to chrome's.


